### PR TITLE
Define constants as extern

### DIFF
--- a/SHNUnitBezier.h
+++ b/SHNUnitBezier.h
@@ -16,12 +16,12 @@ typedef struct {
 	double ay;
 } SHNUnitBezier;
 
-const SHNUnitBezier SHNUnitBezierLinear;
+extern const SHNUnitBezier SHNUnitBezierLinear;
 
-const SHNUnitBezier SHNUnitBezierEase;
-const SHNUnitBezier SHNUnitBezierEaseIn;
-const SHNUnitBezier SHNUnitBezierEaseOut;
-const SHNUnitBezier SHNUnitBezierEaseInOut;
+extern const SHNUnitBezier SHNUnitBezierEase;
+extern const SHNUnitBezier SHNUnitBezierEaseIn;
+extern const SHNUnitBezier SHNUnitBezierEaseOut;
+extern const SHNUnitBezier SHNUnitBezierEaseInOut;
 
 /**
  * Create a unit bezier with polynomial coefficients pre-calculated based on the control points


### PR DESCRIPTION
Hi there,

Nice little lib. Unfortunately it doesn't compile (at least for the simulator) since the constants aren't defined as `extern`, so there will be duplicate symbol errors. Strangely, this is not a problem when building for device... This is with a small playground project with default build settings, so no other complicated dependencies.
